### PR TITLE
Discover GPG Public Key of GitHub User

### DIFF
--- a/discovery.md
+++ b/discovery.md
@@ -1,4 +1,8 @@
 Discovery
 =========
 
-...to be written
+# GitHub
+
+Their GPG Public Key is returned by appending `.gpg` to their GitHub User URL i.e. https://github.com/${user}.gpg
+
+For example, https://github.com/cmlh.gpg returns the GPG Public Key of GitHub account `cmlh`  


### PR DESCRIPTION
I could not locate a reference in the @GitHub documentation for the `.gpg` URI.

Please let me know if there is a test @GitHub user that you'd prefer I used? 